### PR TITLE
cw: honor .worktreeinclude so skills work in worktrees

### DIFF
--- a/.local/bin/cw
+++ b/.local/bin/cw
@@ -24,9 +24,11 @@ fi
 
 root="$(git rev-parse --show-toplevel)"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# claude-worktree-history.sh is an internal helper for cw, not a public command,
-# so it lives in libexec (sibling of bin) rather than on PATH.
+# claude-worktree-history.sh / claude-worktree-include.sh are internal helpers
+# for cw, not public commands, so they live in libexec (sibling of bin) rather
+# than on PATH.
 history_tool="$script_dir/../libexec/claude-worktree-history.sh"
+include_tool="$script_dir/../libexec/claude-worktree-include.sh"
 dir="$root/.claude/worktrees/$name"
 branch="worktree-$name"
 claude_status=0
@@ -62,6 +64,11 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+
+# Copy gitignored paths from .worktreeinclude (e.g. installed skills) into the
+# worktree; `git worktree add` checks out tracked files only. Independent of the
+# history seed/finish below.
+"$include_tool" "$root" "$dir"
 
 "$history_tool" seed "$root" "$dir"
 

--- a/.local/libexec/claude-worktree-include.sh
+++ b/.local/libexec/claude-worktree-include.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Internal helper for `cw` -- NOT a public command.
+# Invoked by cw (which locates it via libexec/) to copy the gitignored paths
+# listed in <repo-root>/.worktreeinclude into a freshly created worktree. This
+# mirrors `claude -w`, which honors .worktreeinclude so installed skills (and
+# any other listed untracked dirs) are available inside the worktree; plain
+# `git worktree add` checks out tracked files only and would leave them behind.
+# Not meant to be run directly; the interface below may change without notice.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+internal helper for cw; not intended to be run directly. usage:
+  libexec/claude-worktree-include.sh <repo-root> <worktree-dir>
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 2
+fi
+
+repo_root="${1%/}"
+worktree_dir="${2%/}"
+include_file="$repo_root/.worktreeinclude"
+
+# No .worktreeinclude: nothing to do (mirrors `claude -w`).
+[[ -f "$include_file" ]] || exit 0
+
+copied=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # Trim surrounding whitespace.
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  # Skip blank lines and comments.
+  [[ -z "$line" || "$line" == \#* ]] && continue
+
+  rel="${line%/}"
+  src="$repo_root/$rel"
+  dest="$worktree_dir/$rel"
+
+  if [[ ! -e "$src" ]]; then
+    echo "worktreeinclude: skip (missing in repo): $rel" >&2
+    continue
+  fi
+  if [[ -e "$dest" ]]; then
+    # Already present (e.g. tracked and checked out); don't clobber.
+    continue
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp -R "$src" "$dest"
+  copied=$((copied + 1))
+done < "$include_file"
+
+echo "worktreeinclude: copied $copied path(s) into $worktree_dir" >&2

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ dotfiles="
 .local/bin/gsync
 .local/bin/cw
 .local/libexec/claude-worktree-history.sh
+.local/libexec/claude-worktree-include.sh
 "
 
 mkdir -p ~/.local/bin ~/.local/libexec ~/.config/uv

--- a/tests.sh
+++ b/tests.sh
@@ -31,6 +31,32 @@ which it2ul
 which tmx
 which cw
 
+# cw internal helpers (installed into ~/.local/libexec)
+test -x ~/.local/libexec/claude-worktree-history.sh
+test -x ~/.local/libexec/claude-worktree-include.sh
+
+# Functional test: claude-worktree-include.sh copies .worktreeinclude paths
+# (e.g. gitignored skills) into a freshly created worktree.
+cw_repo="$(mktemp -d)"
+(
+  cd "$cw_repo"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p .claude/skills/foo
+  echo marker > .claude/skills/foo/SKILL.md
+  printf '.claude/skills/\n' > .gitignore
+  printf '.claude/skills/\n' > .worktreeinclude
+  git add .gitignore .worktreeinclude
+  git commit -qm init
+  git worktree add -q wt -b wt-include-test
+  ~/.local/libexec/claude-worktree-include.sh "$cw_repo" "$cw_repo/wt"
+  test -f "$cw_repo/wt/.claude/skills/foo/SKILL.md"
+  git worktree remove --force wt
+)
+rm -rf "$cw_repo"
+echo "ok [cw worktreeinclude]"
+
 echo "-------------------------------"
 echo "All tests passed!"
 echo "-------------------------------"


### PR DESCRIPTION
## 背景 / なぜ

`cw`（一時 git worktree を作って Claude Code を起動するラッパ）の中で `.worktreeinclude` が効かず、worktree 内で skill が使えなかった。

- `.worktreeinclude` は **純正の `claude -w` だけが解釈する**機能（`~/me` #214 で `claude -w` 用に追加されたもの）。
- `cw` は素の `git worktree add` で worktree を作る。これは tracked ファイルしかチェックアウトせず、gitignore 済みの `.claude/skills/` `.agents/skills/`（`gh skill install` で入る生成物）はコピーされない。
- `cw` が `claude -w` を使わず自前で worktree を作る**唯一の理由は履歴共有**（`claude-worktree-history.sh` が worktree のライフサイクルに seed/finish をフックするため。`claude -w` は worktree を内部管理するので不可）。

履歴共有（`history.jsonl` 操作）と skill 持ち込み（ディレクトリのコピー）は独立。よって `.worktreeinclude` の処理を1ステップ足すだけで両立できる。

## 変更

- **新規 `.local/libexec/claude-worktree-include.sh`**: `claude-worktree-history.sh` と対称な内部 helper。`<repo-root>/.worktreeinclude` の各行を worktree へ `cp -R`（`claude -w` と同じくコピー方式）。`.worktreeinclude` 不在は no-op、src 欠落は skip して継続、既存 dest は clobber しない。
- **`.local/bin/cw`**: cleanup trap 設定後・履歴 seed の直前に helper を1行呼ぶ（コピー失敗時も既存 cleanup で中途半端な worktree を撤去）。履歴 seed/finish は無変更。
- **`install.sh`**: 新 helper を symlink 対象に追加。
- **`tests.sh`**: 使い捨てリポジトリで helper のコピー挙動を検証する機能テストを追加。

## 検証

- helper 単体テスト（コピー前 不在 → コピー後 存在）: PASS
- 実 `~/me` リポジトリへの E2E（fresh worktree に 2 パス・25 skill コピー）: PASS
- エッジ（`.worktreeinclude` 無し→exit 0 / src 欠落→skip 継続）: PASS
- `bash -n` cw・helper、`zsh -n` tests.sh: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)