### PR TITLE
fzf: migrate from git-clone install to brew

### DIFF
--- a/.zshrc.common
+++ b/.zshrc.common
@@ -107,3 +107,9 @@ fi
 
 eval "$(zoxide init zsh)"
 
+##########################################
+# fzf (key bindings & completion)
+##########################################
+
+command -v fzf 1>/dev/null 2>&1 && source <(fzf --zsh)
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ The repository follows a modular approach:
    - `install.sh`: Main installation script that:
      - Installs oh-my-zsh
      - Installs Homebrew (if not present)
-     - Installs development tools via brew (tmux, gh, bat, neovim, ripgrep, etc.)
+     - Installs development tools via brew (tmux, gh, bat, neovim, ripgrep, fzf, etc.)
      - Symlinks dotfiles to home directory
-     - Sets up fzf, iterm2 utilities, uv, and language servers
+     - Sets up iterm2 utilities, uv, and language servers
 
 2. **Dotfiles Structure**:
    - Configuration files are kept in the repository root (`.vimrc`, `.gitconfig`, `.tmux.conf`, etc.)

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,15 @@ fi
 
 # install packages using brew
 # * ripgrep is required by kickstart.nvim
-brew install tmux gh bat xsel tree pygments wget aichat neovim ripgrep node zoxide diff-so-fancy jq 2>/dev/null
+brew install tmux gh bat xsel tree pygments wget aichat neovim ripgrep node zoxide diff-so-fancy jq fzf 2>/dev/null
+
+# clean up old git-based fzf installation (now managed by brew)
+if [[ -e ~/.fzf ]]; then
+  rm -rf ~/.fzf ~/.fzf.zsh ~/.fzf.bash
+  [[ -e ~/.zshrc ]] && sed -i.bak '/\.fzf\.zsh/d' ~/.zshrc && rm -f ~/.zshrc.bak
+  [[ -e ~/.bashrc ]] && sed -i.bak '/\.fzf\.bash/d' ~/.bashrc && rm -f ~/.bashrc.bak
+  echo "removed old git-based fzf (replaced by brew fzf)"
+fi
 
 echo "#############################################################################"
 echo "# Set dotfiles"
@@ -71,17 +79,6 @@ mkdir -p ~/.local/bin ~/.local/libexec ~/.config/uv
 for dotfile in ${dotfiles}; do
     ln -sfnv $(pwd)/${dotfile} ~/${dotfile}
 done
-
-echo "#############################################################################"
-echo "# fzf"
-echo "#############################################################################"
-
-if [[ ! -e ~/.fzf ]]; then
-    git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-    ~/.fzf/install --all --key-bindings --completion --update-rc
-else
-    echo "passed [fzf]"
-fi
 
 echo "#############################################################################"
 echo "# iterm2 utilities"


### PR DESCRIPTION
## Summary
- `p` / `i` が `not a valid integer: ~15` で動かない問題の修正。原因は git clone 方式でインストールされた fzf が初回 clone 時のバージョン (0.29.0) に固定され、`--height=~N` 構文 (fzf 0.34+) を解釈できなかったこと
- fzf のインストールを git clone 方式から brew に移行 (`install.sh` の brew パッケージ一覧に追加し、`~/.fzf` clone セクションを削除)
- 旧 git 版の残骸 (`~/.fzf`, `~/.fzf.zsh`, `~/.fzf.bash` と rc ファイルの読み込み行) を `install.sh` 実行時に自動クリーンアップ (idempotent)
- キーバインド (Ctrl-R / Ctrl-T) と補完は `.zshrc.common` から `source <(fzf --zsh)` で読み込むように変更

## Test plan
- [x] `./tests.sh` が全て通ることを確認
- [x] 新しいシェルで brew 版 fzf (`/opt/homebrew/bin/fzf`, 0.74.1) が解決されることを確認
- [x] `--height=~15` がエラーなくパースされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)